### PR TITLE
Add HTTP / HTTPS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ From within the container, the kibana container is reached at hostname "kibana",
 
 ## Connection
 
-You can access the Kibana server directly from the host by visiting `https://<projectname>.ddev.site:5601`
+You can access the Kibana server directly from the host by visiting:
+
+- `https://<projectname>.ddev.site:5601`
+- `http://<projectname>.ddev.site:5600`
 
 ## Version for Kibana
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Uses [Kibana official image](https://registry.hub.docker.com/_/kibana)
 
 `ddev get janopl/ddev-kibana`
 
-## Configuration 
+## Configuration
 
-From within the container, the kibana container is reached at hostname "kibana", port: 5601 
+From within the container, the kibana container is reached at hostname "kibana", port: 5601
 
-## Connection 
+## Connection
 
 You can access the Kibana server directly from the host by visiting `https://<projectname>.ddev.site:5601`
 
 ## Version for Kibana
 
-Version is depends on image using in official addon [drud/ddev-elasticsearch](https://github.com/drud/ddev-elasticsearch)  
+Version is depends on image using in official addon [drud/ddev-elasticsearch](https://github.com/drud/ddev-elasticsearch)

--- a/docker-compose.kibana.yaml
+++ b/docker-compose.kibana.yaml
@@ -10,7 +10,8 @@ services:
     environment:
       ELASTICSEARCH_HOSTS: '["http://ddev-${DDEV_SITENAME}-elasticsearch:9200"]'
       VIRTUAL_HOST: $DDEV_HOSTNAME
-      HTTP_EXPOSE: 5601:5601
+      HTTP_EXPOSE: 5600:5601
+      HTTPS_EXPOSE: 5601:5601
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT


### PR DESCRIPTION
This PR moves the default service to HTTPS (via 5601), but still allows access via HTTP (via 5600).

Fixes #3


