### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,17 @@
 
 Uses [Kibana official image](https://registry.hub.docker.com/_/kibana)
 
-`ddev get janopl/ddev-kibana`
+For DDEV v1.23.5 or above run
+
+```sh
+ddev add-on get janopl/ddev-kibana
+```
+
+For earlier versions of DDEV run
+
+```sh
+ddev get janopl/ddev-kibana
+```
 
 ## Configuration
 
@@ -28,7 +38,7 @@ services:
 
 OR 
 
-Post ddev get, run ```cp .ddev/elasticsearch/docker-compose.elasticsearch8.yaml .ddev/``` to enable Kibana 8.
+After adding the add-on, run ```cp .ddev/elasticsearch/docker-compose.elasticsearch8.yaml .ddev/``` to enable Kibana 8.
 
 ### Configuration file
 You can configure Kibana dashboard through the config file under: ```.ddev/kibana/config.yml```


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.