### PR TITLE
Update Elasticsearch dependency in install.yaml

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -8,7 +8,7 @@ project_files:
   - ./kibana/docker-compose.kibana8.yaml
 
 dependencies:
-  - elasticsearch
+  - ddev/ddev-elasticsearch
 
 global_files:
 


### PR DESCRIPTION
In upcoming DDEV version v1.24.8, `ddev add-on get` will try to download dependencies, so the `dependencies` list has to show where the dependencies can come from. Please pull this and make a new release, thanks!

